### PR TITLE
Fix `pub const split = @compileError("deprecated; use splitSequence, …

### DIFF
--- a/src/parser.zig
+++ b/src/parser.zig
@@ -23,7 +23,7 @@ pub const Parser = struct {
             if (std.mem.startsWith(u8, line, "#")) continue;
             if (std.mem.eql(u8, line, "")) continue;
 
-            var split_iter = std.mem.split(u8, line, "=");
+            var split_iter = std.mem.splitScalar(u8, line, '=');
 
             var key = split_iter.next() orelse "";
             var value = split_iter.next() orelse "";


### PR DESCRIPTION
This one-one PR fixes build error when using Zig 0.14-dev.